### PR TITLE
Remove throw helpers (resolves #80)

### DIFF
--- a/X10D.DSharpPlus/src/DiscordChannelExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordChannelExtensions.cs
@@ -19,14 +19,10 @@ public static class DiscordChannelExtensions
     /// <exception cref="ArgumentNullException"><paramref name="channel" /> is <see langword="null" />.</exception>
     public static DiscordChannel? GetCategory(this DiscordChannel channel)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(channel);
-#else
         if (channel is null)
         {
             throw new ArgumentNullException(nameof(channel));
         }
-#endif
 
         while (true)
         {
@@ -60,10 +56,6 @@ public static class DiscordChannelExtensions
     /// </exception>
     public static async Task<DiscordChannel> NormalizeClientAsync(this DiscordChannel channel, DiscordClient client)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(channel);
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (channel is null)
         {
             throw new ArgumentNullException(nameof(channel));
@@ -73,7 +65,6 @@ public static class DiscordChannelExtensions
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         return await client.GetChannelAsync(channel.Id).ConfigureAwait(false);
     }

--- a/X10D.DSharpPlus/src/DiscordClientExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordClientExtensions.cs
@@ -20,14 +20,10 @@ public static class DiscordClientExtensions
     /// <exception cref="ArgumentNullException"><paramref name="client" /> is <see langword="null" />.</exception>
     public static void AutoJoinThreads(this DiscordClient client, bool rejoinIfRemoved = true)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (client is null)
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         client.GuildAvailable += (_, args) => args.Guild.JoinAllThreadsAsync();
         client.ThreadCreated += (_, args) => args.Thread.JoinThreadAsync();
@@ -53,14 +49,10 @@ public static class DiscordClientExtensions
     /// <exception cref="ArgumentNullException"><paramref name="client" /> is <see langword="null" />.</exception>
     public static async Task<DiscordUser?> GetUserOrNullAsync(this DiscordClient client, ulong userId)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (client is null)
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         try
         {

--- a/X10D.DSharpPlus/src/DiscordEmbedBuilderExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordEmbedBuilderExtensions.cs
@@ -23,14 +23,10 @@ public static class DiscordEmbedBuilderExtensions
         T? value,
         bool inline = false)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
-#endif
 
         return builder.AddField(name, value?.ToString(), inline);
     }
@@ -53,14 +49,10 @@ public static class DiscordEmbedBuilderExtensions
         T? value,
         bool inline = false)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
-#endif
 
         if (condition)
         {
@@ -92,10 +84,6 @@ public static class DiscordEmbedBuilderExtensions
         T? value,
         bool inline = false)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -105,7 +93,6 @@ public static class DiscordEmbedBuilderExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (predicate.Invoke())
         {
@@ -139,11 +126,6 @@ public static class DiscordEmbedBuilderExtensions
         Func<T?> valueFactory,
         bool inline = false)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(predicate);
-        ArgumentNullException.ThrowIfNull(valueFactory);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
@@ -158,7 +140,6 @@ public static class DiscordEmbedBuilderExtensions
         {
             throw new ArgumentNullException(nameof(valueFactory));
         }
-#endif
 
         if (predicate.Invoke())
         {
@@ -190,19 +171,15 @@ public static class DiscordEmbedBuilderExtensions
         Func<T?> valueFactory,
         bool inline = false)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(valueFactory);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
+
         if (valueFactory is null)
         {
             throw new ArgumentNullException(nameof(valueFactory));
         }
-#endif
 
         if (condition)
         {
@@ -220,19 +197,15 @@ public static class DiscordEmbedBuilderExtensions
     /// <returns>The current instance of <see cref="DiscordEmbedBuilder" />.</returns>
     public static DiscordEmbedBuilder WithAuthor(this DiscordEmbedBuilder builder, DiscordUser user)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(builder);
-        ArgumentNullException.ThrowIfNull(user);
-#else
         if (builder is null)
         {
             throw new ArgumentNullException(nameof(builder));
         }
+
         if (user is null)
         {
             throw new ArgumentNullException(nameof(user));
         }
-#endif
 
         return builder.WithAuthor(user.GetUsernameWithDiscriminator(), iconUrl: user.AvatarUrl);
     }

--- a/X10D.DSharpPlus/src/DiscordGuildExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordGuildExtensions.cs
@@ -16,14 +16,10 @@ public static class DiscordGuildExtensions
     /// <exception cref="ArgumentNullException"><paramref name="guild" /> is <see langword="null" />.</exception>
     public static async Task JoinAllThreadsAsync(this DiscordGuild guild)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(guild);
-#else
         if (guild is null)
         {
             throw new ArgumentNullException(nameof(guild));
         }
-#endif
 
         await Task.WhenAll(guild.Threads.Values.Select(t => t.JoinThreadAsync())).ConfigureAwait(false);
     }
@@ -37,14 +33,10 @@ public static class DiscordGuildExtensions
     /// <exception cref="ArgumentNullException"><paramref name="guild" /> is <see langword="null" />.</exception>
     public static async Task<DiscordMember?> GetMemberOrNullAsync(this DiscordGuild guild, ulong userId)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(guild);
-#else
         if (guild is null)
         {
             throw new ArgumentNullException(nameof(guild));
         }
-#endif
 
         try
         {
@@ -77,10 +69,6 @@ public static class DiscordGuildExtensions
     /// </exception>
     public static async Task<DiscordGuild> NormalizeClientAsync(this DiscordGuild guild, DiscordClient client)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(guild);
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (guild is null)
         {
             throw new ArgumentNullException(nameof(guild));
@@ -90,7 +78,6 @@ public static class DiscordGuildExtensions
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         return await client.GetGuildAsync(guild.Id).ConfigureAwait(false);
     }

--- a/X10D.DSharpPlus/src/DiscordMemberExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordMemberExtensions.cs
@@ -18,10 +18,6 @@ public static class DiscordMemberExtensions
     /// </returns>
     public static bool HasRole(this DiscordMember member, DiscordRole role)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-        ArgumentNullException.ThrowIfNull(role);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
@@ -31,7 +27,6 @@ public static class DiscordMemberExtensions
         {
             throw new ArgumentNullException(nameof(role));
         }
-#endif
 
         return member.Roles.Contains(role);
     }
@@ -52,10 +47,6 @@ public static class DiscordMemberExtensions
     /// </exception>
     public static async Task<DiscordMember> NormalizeClientAsync(this DiscordMember member, DiscordClient client)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
@@ -65,7 +56,6 @@ public static class DiscordMemberExtensions
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         DiscordGuild guild = await member.Guild.NormalizeClientAsync(client).ConfigureAwait(false);
         return await guild.GetMemberAsync(member.Id).ConfigureAwait(false);

--- a/X10D.DSharpPlus/src/DiscordMessageExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordMessageExtensions.cs
@@ -17,14 +17,10 @@ public static class DiscordMessageExtensions
     /// <exception cref="ArgumentNullException"><paramref name="message" /> is <see langword="null" />.</exception>
     public static async Task DeleteAfterAsync(this DiscordMessage message, TimeSpan delay, string? reason = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(message);
-#else
         if (message is null)
         {
             throw new ArgumentNullException(nameof(message));
         }
-#endif
 
         await Task.Delay(delay).ConfigureAwait(false);
         await message.DeleteAsync(reason).ConfigureAwait(false);
@@ -39,14 +35,10 @@ public static class DiscordMessageExtensions
     /// <exception cref="ArgumentNullException"><paramref name="task" /> is <see langword="null" />.</exception>
     public static async Task DeleteAfterAsync(this Task<DiscordMessage> task, TimeSpan delay, string? reason = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(task);
-#else
         if (task is null)
         {
             throw new ArgumentNullException(nameof(task));
         }
-#endif
 
         DiscordMessage message = await task.ConfigureAwait(false);
         await message.DeleteAfterAsync(delay, reason).ConfigureAwait(false);
@@ -68,10 +60,6 @@ public static class DiscordMessageExtensions
     /// </exception>
     public static async Task<DiscordMessage> NormalizeClientAsync(this DiscordMessage message, DiscordClient client)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(message);
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (message is null)
         {
             throw new ArgumentNullException(nameof(message));
@@ -81,7 +69,6 @@ public static class DiscordMessageExtensions
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         DiscordChannel channel = await message.Channel.NormalizeClientAsync(client).ConfigureAwait(false);
         return await channel.GetMessageAsync(message.Id).ConfigureAwait(false);

--- a/X10D.DSharpPlus/src/DiscordUserExtensions.cs
+++ b/X10D.DSharpPlus/src/DiscordUserExtensions.cs
@@ -25,10 +25,6 @@ public static class DiscordUserExtensions
     /// </exception>
     public static async Task<DiscordMember?> GetAsMemberOfAsync(this DiscordUser user, DiscordGuild guild)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(guild);
-#else
         if (user is null)
         {
             throw new ArgumentNullException(nameof(user));
@@ -38,7 +34,6 @@ public static class DiscordUserExtensions
         {
             throw new ArgumentNullException(nameof(guild));
         }
-#endif
 
         if (user is DiscordMember member && member.Guild == guild)
         {
@@ -68,14 +63,10 @@ public static class DiscordUserExtensions
     /// <exception cref="ArgumentNullException"><paramref name="user" /> is <see langword="null" />.</exception>
     public static string GetUsernameWithDiscriminator(this DiscordUser user)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(user);
-#else
         if (user is null)
         {
             throw new ArgumentNullException(nameof(user));
         }
-#endif
 
         return $"{user.Username}#{user.Discriminator}";
     }
@@ -91,10 +82,6 @@ public static class DiscordUserExtensions
     /// </returns>
     public static async Task<bool> IsInGuildAsync(this DiscordUser user, DiscordGuild guild)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(guild);
-#else
         if (user is null)
         {
             throw new ArgumentNullException(nameof(user));
@@ -104,7 +91,6 @@ public static class DiscordUserExtensions
         {
             throw new ArgumentNullException(nameof(guild));
         }
-#endif
 
         if (guild.Members.TryGetValue(user.Id, out _))
         {
@@ -138,10 +124,6 @@ public static class DiscordUserExtensions
     /// </exception>
     public static async Task<DiscordUser> NormalizeClientAsync(this DiscordUser user, DiscordClient client)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(user);
-        ArgumentNullException.ThrowIfNull(client);
-#else
         if (user is null)
         {
             throw new ArgumentNullException(nameof(user));
@@ -151,7 +133,6 @@ public static class DiscordUserExtensions
         {
             throw new ArgumentNullException(nameof(client));
         }
-#endif
 
         return await client.GetUserAsync(user.Id).ConfigureAwait(false);
     }

--- a/X10D/src/Collections/ArrayExtensions.cs
+++ b/X10D/src/Collections/ArrayExtensions.cs
@@ -17,14 +17,10 @@ public static class ArrayExtensions
     [Pure]
     public static IReadOnlyCollection<T> AsReadOnly<T>(this T[] array)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(array);
-#else
         if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
-#endif
 
         return Array.AsReadOnly(array);
     }
@@ -49,14 +45,10 @@ public static class ArrayExtensions
     /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
     public static void Clear<T>(this T?[] array, Range range)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(array);
-#else
         if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
-#endif
 
         (int offset, int length) = range.GetOffsetAndLength(array.Length);
         array.Clear(offset, length);
@@ -79,14 +71,10 @@ public static class ArrayExtensions
     /// </exception>
     public static void Clear<T>(this T?[] array, int index, int length)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(array);
-#else
         if (array is null)
         {
             throw new ArgumentNullException(nameof(array));
         }
-#endif
 
         if (length == 0 || array.Length == 0)
         {

--- a/X10D/src/Collections/BoolListExtensions.cs
+++ b/X10D/src/Collections/BoolListExtensions.cs
@@ -18,14 +18,10 @@ public static class BoolListExtensions
     [Pure]
     public static byte PackByte(this IReadOnlyList<bool> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.Count > 8)
         {
@@ -52,14 +48,10 @@ public static class BoolListExtensions
     [Pure]
     public static short PackInt16(this IReadOnlyList<bool> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.Count > 16)
         {
@@ -86,14 +78,10 @@ public static class BoolListExtensions
     [Pure]
     public static int PackInt32(this IReadOnlyList<bool> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.Count > 32)
         {
@@ -120,14 +108,10 @@ public static class BoolListExtensions
     [Pure]
     public static long PackInt64(this IReadOnlyList<bool> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.Count > 64)
         {

--- a/X10D/src/Collections/CollectionExtensions.cs
+++ b/X10D/src/Collections/CollectionExtensions.cs
@@ -16,14 +16,10 @@ public static class CollectionExtensions
     /// <seealso cref="EnumerableExtensions.DisposeAll{T}" />
     public static void ClearAndDisposeAll<T>(this ICollection<T> source) where T : IDisposable
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.IsReadOnly)
         {
@@ -55,14 +51,10 @@ public static class CollectionExtensions
     /// <seealso cref="EnumerableExtensions.DisposeAllAsync{T}" />
     public static async Task ClearAndDisposeAllAsync<T>(this ICollection<T> source) where T : IAsyncDisposable
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source.IsReadOnly)
         {

--- a/X10D/src/Collections/DictionaryExtensions.cs
+++ b/X10D/src/Collections/DictionaryExtensions.cs
@@ -37,10 +37,6 @@ public static class DictionaryExtensions
         Func<TKey, TValue, TValue> updateValueFactory)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -50,7 +46,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
 #if NET6_0_OR_GREATER
         ref var value = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
@@ -97,10 +92,6 @@ public static class DictionaryExtensions
         Func<TKey, TValue, TValue> updateValueFactory)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -110,7 +101,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
         if (dictionary.TryGetValue(key, out TValue? old))
         {
@@ -152,11 +142,6 @@ public static class DictionaryExtensions
         Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(addValueFactory);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -171,7 +156,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
 #if NET6_0_OR_GREATER
         ref TValue? value = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
@@ -222,11 +206,6 @@ public static class DictionaryExtensions
         Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(addValueFactory);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -241,7 +220,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
         if (dictionary.TryGetValue(key, out TValue? old))
         {
@@ -291,11 +269,6 @@ public static class DictionaryExtensions
         Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(addValueFactory);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -310,7 +283,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
 #if NET6_0_OR_GREATER
         ref TValue? value = ref CollectionsMarshal.GetValueRefOrAddDefault(dictionary, key, out bool exists);
@@ -367,11 +339,6 @@ public static class DictionaryExtensions
         Func<TKey, TArg, TValue> addValueFactory, Func<TKey, TValue, TArg, TValue> updateValueFactory, TArg factoryArgument)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(dictionary);
-        ArgumentNullException.ThrowIfNull(addValueFactory);
-        ArgumentNullException.ThrowIfNull(updateValueFactory);
-#else
         if (dictionary is null)
         {
             throw new ArgumentNullException(nameof(dictionary));
@@ -386,7 +353,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(updateValueFactory));
         }
-#endif
 
         if (dictionary.TryGetValue(key, out TValue? old))
         {
@@ -414,14 +380,10 @@ public static class DictionaryExtensions
     [Pure]
     public static string ToConnectionString<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         static string SanitizeValue(string? value)
         {
@@ -461,10 +423,6 @@ public static class DictionaryExtensions
     public static string ToConnectionString<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source,
         Func<TValue, string?> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -474,7 +432,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         static string SanitizeValue(string? value)
         {
@@ -520,11 +477,6 @@ public static class DictionaryExtensions
         Func<TKey, string> keySelector, Func<TValue, string?> valueSelector)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(keySelector);
-        ArgumentNullException.ThrowIfNull(valueSelector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -539,7 +491,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(valueSelector));
         }
-#endif
 
         static string SanitizeValue(string? value)
         {
@@ -571,14 +522,10 @@ public static class DictionaryExtensions
     public static string ToGetParameters<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         static string GetQueryParameter(KeyValuePair<TKey, TValue> pair)
         {
@@ -610,10 +557,6 @@ public static class DictionaryExtensions
         Func<TValue, string?> selector)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -623,7 +566,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         // can't static here because of 'selector' parameter
         string GetQueryParameter(KeyValuePair<TKey, TValue> pair)
@@ -661,11 +603,6 @@ public static class DictionaryExtensions
         Func<TKey, string> keySelector, Func<TValue, string?> valueSelector)
         where TKey : notnull
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(keySelector);
-        ArgumentNullException.ThrowIfNull(valueSelector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -680,7 +617,6 @@ public static class DictionaryExtensions
         {
             throw new ArgumentNullException(nameof(valueSelector));
         }
-#endif
 
         // can't static here because of selector parameters
         string GetQueryParameter(KeyValuePair<TKey, TValue> pair)

--- a/X10D/src/Collections/EnumerableExtensions.cs
+++ b/X10D/src/Collections/EnumerableExtensions.cs
@@ -24,10 +24,6 @@ public static class EnumerableExtensions
     [Pure]
     public static int CountWhereNot<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -37,7 +33,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.Count(item => !predicate(item));
     }
@@ -58,10 +53,6 @@ public static class EnumerableExtensions
     [Pure]
     public static TSource FirstWhereNot<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -71,7 +62,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.First(item => !predicate(item));
     }
@@ -91,10 +81,6 @@ public static class EnumerableExtensions
     [Pure]
     public static TSource? FirstWhereNotOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -104,7 +90,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.FirstOrDefault(item => !predicate(item));
     }
@@ -127,10 +112,6 @@ public static class EnumerableExtensions
     /// </exception>
     public static void For<T>(this IEnumerable<T> source, Action<int, T> action)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(action);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -140,7 +121,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(action));
         }
-#endif
 
         var index = 0;
         foreach (T item in source)
@@ -166,10 +146,6 @@ public static class EnumerableExtensions
     /// </exception>
     public static void ForEach<T>(this IEnumerable<T> source, Action<T> action)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(action);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -179,7 +155,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(action));
         }
-#endif
 
         foreach (T item in source)
         {
@@ -196,14 +171,10 @@ public static class EnumerableExtensions
     /// <seealso cref="CollectionExtensions.ClearAndDisposeAll{T}" />
     public static void DisposeAll<T>(this IEnumerable<T> source) where T : IDisposable
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         foreach (T item in source)
         {
@@ -227,14 +198,10 @@ public static class EnumerableExtensions
     /// <seealso cref="CollectionExtensions.ClearAndDisposeAllAsync{T}" />
     public static async Task DisposeAllAsync<T>(this IEnumerable<T> source) where T : IAsyncDisposable
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         foreach (T item in source)
         {
@@ -264,10 +231,6 @@ public static class EnumerableExtensions
     [Pure]
     public static TSource LastWhereNot<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -277,7 +240,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.Last(item => !predicate(item));
     }
@@ -297,10 +259,6 @@ public static class EnumerableExtensions
     [Pure]
     public static TSource? LastWhereNotOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -310,7 +268,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.LastOrDefault(item => !predicate(item));
     }
@@ -326,14 +283,10 @@ public static class EnumerableExtensions
     [Pure]
     public static IReadOnlyCollection<T> Shuffled<T>(this IEnumerable<T> source, Random? random = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         var list = new List<T>(source);
         list.Shuffle(random);
@@ -355,10 +308,6 @@ public static class EnumerableExtensions
     [Pure]
     public static IEnumerable<TSource> WhereNot<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -368,7 +317,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         return source.Where(item => !predicate(item));
     }
@@ -386,14 +334,10 @@ public static class EnumerableExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static IEnumerable<TSource> WhereNotNull<TSource>(this IEnumerable<TSource?> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Where(item => item is not null).Select(item => item!);
     }

--- a/X10D/src/Collections/ListExtensions.cs
+++ b/X10D/src/Collections/ListExtensions.cs
@@ -19,14 +19,10 @@ public static class ListExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static void Fill<T>(this IList<T> source, T value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         for (var i = 0; i < source.Count; i++)
         {
@@ -53,14 +49,10 @@ public static class ListExtensions
     /// </exception>
     public static void Fill<T>(this IList<T> source, T value, int startIndex, int count)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (startIndex < 0)
         {
@@ -105,14 +97,10 @@ public static class ListExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static int IndexOf<T>(this IReadOnlyList<T?> source, T? item)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.IndexOf(item, 0, source.Count);
     }
@@ -138,14 +126,10 @@ public static class ListExtensions
     /// </exception>
     public static int IndexOf<T>(this IReadOnlyList<T?> source, T? item, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.IndexOf(item, startIndex, source.Count - startIndex);
     }
@@ -182,14 +166,10 @@ public static class ListExtensions
     /// </exception>
     public static int IndexOf<T>(this IReadOnlyList<T?> source, T? item, int startIndex, int count)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (startIndex < 0 || startIndex > source.Count)
         {
@@ -233,14 +213,10 @@ public static class ListExtensions
     [Pure]
     public static T Random<T>(this IReadOnlyList<T> source, Random? random = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         random ??= RandomExtensions.GetShared();
         return random.NextFrom(source);
@@ -260,14 +236,10 @@ public static class ListExtensions
     /// </exception>
     public static void RemoveRange<T>(this IList<T> source, Range range)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         int start = range.Start.IsFromEnd ? source.Count - range.Start.Value : range.Start.Value;
         int end = range.End.IsFromEnd ? source.Count - range.End.Value : range.End.Value;
@@ -300,14 +272,10 @@ public static class ListExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static void Shuffle<T>(this IList<T> source, Random? random = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         random ??= RandomExtensions.GetShared();
 
@@ -334,14 +302,10 @@ public static class ListExtensions
     /// </exception>
     public static IReadOnlyList<T> Slice<T>(this IReadOnlyList<T> source, int start)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Slice(start, source.Count - start);
     }
@@ -363,14 +327,10 @@ public static class ListExtensions
     /// </exception>
     public static IReadOnlyList<T> Slice<T>(this IReadOnlyList<T> source, int start, int length)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (start < 0 || start > source.Count)
         {
@@ -406,10 +366,6 @@ public static class ListExtensions
     /// </exception>
     public static void Swap<T>(this IList<T> source, IList<T> other)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(other);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -419,7 +375,6 @@ public static class ListExtensions
         {
             throw new ArgumentNullException(nameof(other));
         }
-#endif
 
         int min = System.Math.Min(source.Count, other.Count);
         for (var index = 0; index < min; index++)

--- a/X10D/src/Core/RandomExtensions.cs
+++ b/X10D/src/Core/RandomExtensions.cs
@@ -27,14 +27,10 @@ public static class RandomExtensions
     public static T Next<T>(this Random random)
         where T : struct, Enum
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         var values = Enum.GetValues(typeof(T));
         return (T)values.GetValue(random.Next(values.Length))!;
@@ -54,14 +50,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static bool NextBoolean(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return random.NextDouble() >= 0.5;
     }
@@ -81,14 +73,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxValue" /> is less than 0.</exception>
     public static double NextDouble(this Random random, double maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         if (maxValue < 0)
         {
@@ -117,14 +105,10 @@ public static class RandomExtensions
     /// </exception>
     public static double NextDouble(this Random random, double minValue, double maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         if (maxValue < minValue)
         {
@@ -155,10 +139,6 @@ public static class RandomExtensions
     /// </example>
     public static T NextFrom<T>(this Random random, IEnumerable<T> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
@@ -168,7 +148,6 @@ public static class RandomExtensions
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (source is T[] array)
         {
@@ -206,14 +185,10 @@ public static class RandomExtensions
     /// </example>
     public static T NextFrom<T>(this Random random, Span<T> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return source[random.Next(source.Length)];
     }
@@ -242,14 +217,10 @@ public static class RandomExtensions
     /// </example>
     public static T NextFrom<T>(this Random random, ReadOnlySpan<T> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return source[random.Next(source.Length)];
     }
@@ -264,14 +235,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static byte NextByte(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return random.NextByte(byte.MaxValue);
     }
@@ -292,14 +259,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static byte NextByte(this Random random, byte maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return random.NextByte(0, maxValue);
     }
@@ -325,14 +288,10 @@ public static class RandomExtensions
     /// </exception>
     public static byte NextByte(this Random random, byte minValue, byte maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return (byte)random.Next(minValue, maxValue);
     }
@@ -347,14 +306,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static short NextInt16(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return random.NextInt16(short.MaxValue);
     }
@@ -376,14 +331,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maxValue" /> is less than 0.</exception>
     public static short NextInt16(this Random random, short maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         if (maxValue < 0)
         {
@@ -414,14 +365,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static short NextInt16(this Random random, short minValue, short maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         return (short)random.Next(minValue, maxValue);
     }
@@ -459,14 +406,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentException"><paramref name="maxValue" /> is less than 0.</exception>
     public static float NextSingle(this Random random, float maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         if (maxValue < 0)
         {
@@ -495,14 +438,10 @@ public static class RandomExtensions
     /// </exception>
     public static float NextSingle(this Random random, float minValue, float maxValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         if (maxValue < minValue)
         {
@@ -530,10 +469,6 @@ public static class RandomExtensions
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="length" /> is less than 0.</exception>
     public static string NextString(this Random random, IReadOnlyList<char> source, int length)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
@@ -543,7 +478,6 @@ public static class RandomExtensions
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (length < 0)
         {

--- a/X10D/src/Drawing/Polygon.cs
+++ b/X10D/src/Drawing/Polygon.cs
@@ -22,14 +22,10 @@ public class Polygon : IEquatable<Polygon>
     /// </summary>
     public Polygon(Polygon polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
 
         _vertices = new List<Point>();
         for (var index = 0; index < polygon._vertices.Count; index++)
@@ -45,14 +41,10 @@ public class Polygon : IEquatable<Polygon>
     /// <param name="vertices">An enumerable collection of vertices from which the polygon should be constructed.</param>
     public Polygon(IEnumerable<Point> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         _vertices = new List<Point>(vertices);
     }
@@ -176,14 +168,10 @@ public class Polygon : IEquatable<Polygon>
     /// <exception cref="ArgumentNullException"><paramref name="polygon" /> is <see langword="null" />.</exception>
     public static Polygon FromPolygonF(PolygonF polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
 
         var vertices = new List<Point>();
 
@@ -211,14 +199,10 @@ public class Polygon : IEquatable<Polygon>
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public void AddVertices(IEnumerable<Point> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         foreach (Point vertex in vertices)
         {

--- a/X10D/src/Drawing/PolygonF.cs
+++ b/X10D/src/Drawing/PolygonF.cs
@@ -25,14 +25,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="polygon" /> is <see langword="null" />.</exception>
     public PolygonF(PolygonF polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
         _vertices = new List<PointF>();
         for (var index = 0; index < polygon._vertices.Count; index++)
         {
@@ -48,14 +44,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public PolygonF(IEnumerable<Vector2> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         _vertices = new List<PointF>();
         foreach (Vector2 vertex in vertices)
@@ -71,14 +63,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public PolygonF(IEnumerable<PointF> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         _vertices = new List<PointF>(vertices);
     }
@@ -202,14 +190,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="polygon" /> is <see langword="null" />.</exception>
     public static PolygonF FromPolygon(Polygon polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
 
         var vertices = new List<PointF>();
 
@@ -246,14 +230,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public void AddVertices(IEnumerable<PointF> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         foreach (PointF vertex in vertices)
         {
@@ -268,14 +248,10 @@ public class PolygonF
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public void AddVertices(IEnumerable<Vector2> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         foreach (Vector2 vertex in vertices)
         {

--- a/X10D/src/Drawing/Polyhedron.cs
+++ b/X10D/src/Drawing/Polyhedron.cs
@@ -34,14 +34,10 @@ public class Polyhedron : IEquatable<Polyhedron>
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public Polyhedron(IEnumerable<Vector3> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         _vertices = new List<Vector3>(vertices);
     }
@@ -137,14 +133,10 @@ public class Polyhedron : IEquatable<Polyhedron>
     /// <exception cref="ArgumentNullException"><paramref name="polygon" /> is <see langword="null" />.</exception>
     public static Polyhedron FromPolygon(Polygon polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
 
         var vertices = new List<Vector3>();
 
@@ -164,14 +156,10 @@ public class Polyhedron : IEquatable<Polyhedron>
     /// <exception cref="ArgumentNullException"><paramref name="polygon" /> is <see langword="null" />.</exception>
     public static Polyhedron FromPolygonF(PolygonF polygon)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(polygon);
-#else
         if (polygon is null)
         {
             throw new ArgumentNullException(nameof(polygon));
         }
-#endif
 
         var vertices = new List<Vector3>();
 
@@ -199,14 +187,10 @@ public class Polyhedron : IEquatable<Polyhedron>
     /// <exception cref="ArgumentNullException"><paramref name="vertices" /> is <see langword="null" />.</exception>
     public void AddVertices(IEnumerable<Vector3> vertices)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(vertices);
-#else
         if (vertices is null)
         {
             throw new ArgumentNullException(nameof(vertices));
         }
-#endif
 
         foreach (Vector3 vertex in vertices)
         {

--- a/X10D/src/Drawing/RandomExtensions.cs
+++ b/X10D/src/Drawing/RandomExtensions.cs
@@ -17,14 +17,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static Color NextColorRgb(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         int rgb = random.Next();
         return Color.FromArgb(0xFF, (byte)(rgb >> 16 & 0xFF), (byte)(rgb >> 8 & 0xFF), (byte)(rgb & 0xFF));
@@ -38,14 +34,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static Color NextColorArgb(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         int argb = random.Next();
         return Color.FromArgb(argb);

--- a/X10D/src/IO/DirectoryInfoExtensions.cs
+++ b/X10D/src/IO/DirectoryInfoExtensions.cs
@@ -33,14 +33,10 @@ public static class DirectoryInfoExtensions
     /// <exception cref="UnauthorizedAccessException">This directory or one of its children contain a read-only file.</exception>
     public static void Clear(this DirectoryInfo directory)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(directory);
-#else
         if (directory is null)
         {
             throw new ArgumentNullException(nameof(directory));
         }
-#endif
 
         if (!directory.Exists)
         {

--- a/X10D/src/IO/FileInfoExtensions.cs
+++ b/X10D/src/IO/FileInfoExtensions.cs
@@ -29,14 +29,10 @@ public static class FileInfoExtensions
     public static byte[] GetHash<T>(this FileInfo value)
         where T : HashAlgorithm
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         using FileStream stream = value.OpenRead();
         return stream.GetHash<T>();
@@ -69,14 +65,10 @@ public static class FileInfoExtensions
     public static bool TryWriteHash<T>(this FileInfo value, Span<byte> destination, out int bytesWritten)
         where T : HashAlgorithm
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         using FileStream stream = value.OpenRead();
         return stream.TryWriteHash<T>(destination, out bytesWritten);

--- a/X10D/src/IO/ListOfByteExtensions.cs
+++ b/X10D/src/IO/ListOfByteExtensions.cs
@@ -19,14 +19,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static string AsString(this IReadOnlyList<byte> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToString(source.ToArray());
     }
@@ -54,14 +50,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static double ToDouble(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToDouble(source.ToArray(), startIndex);
     }
@@ -86,14 +78,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static short ToInt16(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToInt16(source.ToArray(), startIndex);
     }
@@ -118,14 +106,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static int ToInt32(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToInt32(source.ToArray(), startIndex);
     }
@@ -150,14 +134,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static long ToInt64(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
         return BitConverter.ToInt64(source.ToArray(), startIndex);
     }
 
@@ -183,14 +163,10 @@ public static class ListOfByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static float ToSingle(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToSingle(source.ToArray(), startIndex);
     }
@@ -208,10 +184,6 @@ public static class ListOfByteExtensions
     /// </exception>
     public static string ToString(this IReadOnlyList<byte> source, Encoding encoding)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(encoding);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -221,7 +193,6 @@ public static class ListOfByteExtensions
         {
             throw new ArgumentNullException(nameof(encoding));
         }
-#endif
 
         return encoding.GetString(source.ToArray());
     }
@@ -248,14 +219,10 @@ public static class ListOfByteExtensions
     [CLSCompliant(false)]
     public static ushort ToUInt16(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToUInt16(source.ToArray(), startIndex);
     }
@@ -282,14 +249,10 @@ public static class ListOfByteExtensions
     [CLSCompliant(false)]
     public static uint ToUInt32(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToUInt32(source.ToArray(), startIndex);
     }
@@ -316,14 +279,10 @@ public static class ListOfByteExtensions
     [CLSCompliant(false)]
     public static ulong ToUInt64(this IReadOnlyList<byte> source, int startIndex)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return BitConverter.ToUInt64(source.ToArray(), startIndex);
     }

--- a/X10D/src/IO/StreamExtensions.cs
+++ b/X10D/src/IO/StreamExtensions.cs
@@ -33,14 +33,10 @@ public static class StreamExtensions
     public static byte[] GetHash<T>(this Stream stream)
         where T : HashAlgorithm
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
         if (!stream.CanRead)
         {
@@ -87,14 +83,10 @@ public static class StreamExtensions
     /// <returns>A decimal value read from the stream.</returns>
     public static decimal ReadDecimal(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -151,14 +143,10 @@ public static class StreamExtensions
     /// <returns>A double-precision floating point value read from the stream.</returns>
     public static double ReadDouble(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -211,14 +199,10 @@ public static class StreamExtensions
     /// <returns>An two-byte unsigned integer read from the stream.</returns>
     public static short ReadInt16(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -265,14 +249,10 @@ public static class StreamExtensions
     /// <returns>An four-byte unsigned integer read from the stream.</returns>
     public static int ReadInt32(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -319,14 +299,10 @@ public static class StreamExtensions
     /// <returns>An eight-byte unsigned integer read from the stream.</returns>
     public static long ReadInt64(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -373,14 +349,10 @@ public static class StreamExtensions
     /// <returns>A single-precision floating point value read from the stream.</returns>
     public static float ReadSingle(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -435,14 +407,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static ushort ReadUInt16(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -491,14 +459,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static uint ReadUInt32(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -547,14 +511,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static ulong ReadUInt64(this Stream stream, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -607,14 +567,10 @@ public static class StreamExtensions
     public static bool TryWriteHash<T>(this Stream stream, Span<byte> destination, out int bytesWritten)
         where T : HashAlgorithm
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
         if (!stream.CanRead)
         {
@@ -671,14 +627,10 @@ public static class StreamExtensions
     /// <returns>The number of bytes written to the stream.</returns>
     public static int Write(this Stream stream, short value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -735,14 +687,10 @@ public static class StreamExtensions
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     public static int Write(this Stream stream, int value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -800,14 +748,10 @@ public static class StreamExtensions
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     public static int Write(this Stream stream, long value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -867,14 +811,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static int Write(this Stream stream, ushort value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -934,14 +874,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static int Write(this Stream stream, uint value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -1001,14 +937,10 @@ public static class StreamExtensions
     [CLSCompliant(false)]
     public static int Write(this Stream stream, ulong value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -1052,14 +984,10 @@ public static class StreamExtensions
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     public static int Write(this Stream stream, float value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -1135,14 +1063,10 @@ public static class StreamExtensions
     /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
     public static int Write(this Stream stream, double value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))
@@ -1219,14 +1143,10 @@ public static class StreamExtensions
     [ExcludeFromCodeCoverage]
     public static int Write(this Stream stream, decimal value, Endianness endianness)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(stream);
-#else
         if (stream is null)
         {
             throw new ArgumentNullException(nameof(stream));
         }
-#endif
 
 #if NET5_0_OR_GREATER
         if (!Enum.IsDefined(endianness))

--- a/X10D/src/IO/TextReaderExtensions.cs
+++ b/X10D/src/IO/TextReaderExtensions.cs
@@ -13,14 +13,10 @@ public static class TextReaderExtensions
     /// <exception cref="ArgumentNullException"><paramref name="reader" /> is <see langword="null" />.</exception>
     public static IEnumerable<string> EnumerateLines(this TextReader reader)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(reader);
-#else
         if (reader is null)
         {
             throw new ArgumentNullException(nameof(reader));
         }
-#endif
 
         while (reader.ReadLine() is { } line)
         {
@@ -36,14 +32,10 @@ public static class TextReaderExtensions
     /// <exception cref="ArgumentNullException"><paramref name="reader" /> is <see langword="null" />.</exception>
     public static async IAsyncEnumerable<string> EnumerateLinesAsync(this TextReader reader)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(reader);
-#else
         if (reader is null)
         {
             throw new ArgumentNullException(nameof(reader));
         }
-#endif
 
         while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
         {

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Double.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Double.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, double value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -41,14 +37,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, double value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteLineNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -68,14 +60,10 @@ public static partial class TextWriterExtensions
     public static void WriteLineNoAlloc(this TextWriter writer, double value, ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Int32.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Int32.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, int value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -41,14 +37,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, int value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteLineNoAlloc(writer, (long)value, format, CultureInfo.CurrentCulture);
     }
@@ -68,14 +60,10 @@ public static partial class TextWriterExtensions
     public static void WriteLineNoAlloc(this TextWriter writer, int value, ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Int64.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Int64.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, long value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -41,14 +37,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, long value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, format, CultureInfo.CurrentCulture);
     }
@@ -70,14 +62,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Single.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.Single.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, float value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -41,14 +37,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteLineNoAlloc(this TextWriter writer, float value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteLineNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -68,14 +60,10 @@ public static partial class TextWriterExtensions
     public static void WriteLineNoAlloc(this TextWriter writer, float value, ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.UInt32.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.UInt32.cs
@@ -17,14 +17,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteLineNoAlloc(this TextWriter writer, uint value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -43,14 +39,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteLineNoAlloc(this TextWriter writer, uint value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteLineNoAlloc(writer, (long)value, format, CultureInfo.CurrentCulture);
     }
@@ -73,14 +65,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.UInt64.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteLineNoAlloc.UInt64.cs
@@ -17,14 +17,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteLineNoAlloc(this TextWriter writer, ulong value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -43,14 +39,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteLineNoAlloc(this TextWriter writer, ulong value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteLineNoAlloc(value, format, CultureInfo.CurrentCulture);
     }
@@ -73,14 +65,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         writer.WriteNoAlloc(value, format, formatProvider);
         writer.WriteLine();

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Double.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Double.cs
@@ -15,14 +15,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, double value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -39,14 +35,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, double value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -65,14 +57,10 @@ public static partial class TextWriterExtensions
     public static void WriteNoAlloc(this TextWriter writer, double value, ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         Span<char> buffer = stackalloc char[100];
         if (value.TryFormat(buffer, out int charsWritten, format, formatProvider))

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Int32.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Int32.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, int value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -40,14 +36,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, int value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -65,14 +57,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, int value, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         int digitCount = value.CountDigits();
         Span<char> buffer = stackalloc char[System.Math.Max(value < 0 ? digitCount + 1 : digitCount, 100)];

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Int64.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Int64.cs
@@ -16,14 +16,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, long value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -40,14 +36,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, long value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -68,14 +60,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         int digitCount = value.CountDigits();
         Span<char> buffer = stackalloc char[System.Math.Max(value < 0 ? digitCount + 1 : digitCount, 100)];

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Single.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.Single.cs
@@ -15,14 +15,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, float value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -39,14 +35,10 @@ public static partial class TextWriterExtensions
     /// <exception cref="IOException">An I/O error occurs.</exception>
     public static void WriteNoAlloc(this TextWriter writer, float value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -65,14 +57,10 @@ public static partial class TextWriterExtensions
     public static void WriteNoAlloc(this TextWriter writer, float value, ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         Span<char> buffer = stackalloc char[100];
         if (value.TryFormat(buffer, out int charsWritten, format, formatProvider))

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.UInt32.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.UInt32.cs
@@ -17,14 +17,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteNoAlloc(this TextWriter writer, uint value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -42,14 +38,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteNoAlloc(this TextWriter writer, uint value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -71,14 +63,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         int digitCount = value.CountDigits();
         Span<char> buffer = stackalloc char[System.Math.Max(digitCount, 100)];

--- a/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.UInt64.cs
+++ b/X10D/src/IO/TextWriterExtensions.WriteNoAlloc.UInt64.cs
@@ -17,14 +17,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteNoAlloc(this TextWriter writer, ulong value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, "N0".AsSpan(), CultureInfo.CurrentCulture);
     }
@@ -42,14 +38,10 @@ public static partial class TextWriterExtensions
     [CLSCompliant(false)]
     public static void WriteNoAlloc(this TextWriter writer, ulong value, ReadOnlySpan<char> format)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         WriteNoAlloc(writer, value, format, CultureInfo.CurrentCulture);
     }
@@ -71,14 +63,10 @@ public static partial class TextWriterExtensions
         ReadOnlySpan<char> format,
         IFormatProvider? formatProvider)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(writer);
-#else
         if (writer is null)
         {
             throw new ArgumentNullException(nameof(writer));
         }
-#endif
 
         int digitCount = value.CountDigits();
         Span<char> buffer = stackalloc char[System.Math.Max(digitCount, 100)];

--- a/X10D/src/Linq/ByteExtensions.cs
+++ b/X10D/src/Linq/ByteExtensions.cs
@@ -15,14 +15,10 @@ public static class ByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static byte Product(this IEnumerable<byte> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate((byte)1, (current, value) => (byte)(current * value));
     }
@@ -36,14 +32,10 @@ public static class ByteExtensions
     [CLSCompliant(false)]
     public static sbyte Product(this IEnumerable<sbyte> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate((sbyte)1, (current, value) => (sbyte)(current * value));
     }
@@ -59,14 +51,10 @@ public static class ByteExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static byte Product<TSource>(this IEnumerable<TSource> source, Func<TSource, byte> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }
@@ -83,14 +71,10 @@ public static class ByteExtensions
     [CLSCompliant(false)]
     public static sbyte Product<TSource>(this IEnumerable<TSource> source, Func<TSource, sbyte> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/DecimalExtensions.cs
+++ b/X10D/src/Linq/DecimalExtensions.cs
@@ -13,14 +13,10 @@ public static class DecimalExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static decimal Product(this IEnumerable<decimal> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1m, (current, value) => (current * value));
     }
@@ -36,14 +32,10 @@ public static class DecimalExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static decimal Product<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/DoubleExtensions.cs
+++ b/X10D/src/Linq/DoubleExtensions.cs
@@ -13,14 +13,10 @@ public static class DoubleExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static double Product(this IEnumerable<double> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1.0, (current, value) => (current * value));
     }
@@ -36,14 +32,10 @@ public static class DoubleExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static double Product<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/EnumerableExtensions.cs
+++ b/X10D/src/Linq/EnumerableExtensions.cs
@@ -22,14 +22,10 @@ public static class EnumerableExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static IEnumerable<TSource> ConcatOne<TSource>(this IEnumerable<TSource> source, TSource value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         foreach (TSource item in source)
         {
@@ -52,14 +48,10 @@ public static class EnumerableExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> source, TSource item)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Where(i => !Equals(i, item));
     }
@@ -74,14 +66,10 @@ public static class EnumerableExtensions
     /// <exception cref="InvalidOperationException"><paramref name="source" /> contains no elements.</exception>
     public static (T? Minimum, T? Maximum) MinMax<T>(this IEnumerable<T> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return MinMax(source, Comparer<T>.Default);
     }
@@ -97,14 +85,10 @@ public static class EnumerableExtensions
     /// <exception cref="InvalidOperationException"><paramref name="source" /> contains no elements.</exception>
     public static (T? Minimum, T? Maximum) MinMax<T>(this IEnumerable<T> source, IComparer<T>? comparer)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         comparer ??= Comparer<T>.Default;
 
@@ -160,10 +144,6 @@ public static class EnumerableExtensions
     public static (TResult? Minimum, TResult? Maximum) MinMax<TSource, TResult>(this IEnumerable<TSource> source,
         Func<TSource, TResult> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -173,7 +153,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         return MinMax(source, selector, Comparer<TResult>.Default);
     }
@@ -194,10 +173,6 @@ public static class EnumerableExtensions
         Func<TSource, TResult> selector,
         IComparer<TResult>? comparer)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -207,7 +182,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         comparer ??= Comparer<TResult>.Default;
 
@@ -263,10 +237,6 @@ public static class EnumerableExtensions
     public static (TSource? Minimum, TSource? Maximum) MinMaxBy<TSource, TResult>(this IEnumerable<TSource> source,
         Func<TSource, TResult> keySelector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(keySelector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -276,7 +246,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(keySelector));
         }
-#endif
 
         return MinMaxBy(source, keySelector, Comparer<TResult>.Default);
     }
@@ -296,10 +265,6 @@ public static class EnumerableExtensions
         Func<TSource, TResult> keySelector,
         IComparer<TResult>? comparer)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(keySelector);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -309,7 +274,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(keySelector));
         }
-#endif
 
         comparer ??= Comparer<TResult>.Default;
         TSource? minValue;

--- a/X10D/src/Linq/Int32Extensions.cs
+++ b/X10D/src/Linq/Int32Extensions.cs
@@ -15,14 +15,10 @@ public static class Int32Extensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static int Product(this IEnumerable<int> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1, (current, value) => current * value);
     }
@@ -36,14 +32,10 @@ public static class Int32Extensions
     [CLSCompliant(false)]
     public static uint Product(this IEnumerable<uint> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1u, (current, value) => current * value);
     }
@@ -59,14 +51,10 @@ public static class Int32Extensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static int Product<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }
@@ -83,14 +71,10 @@ public static class Int32Extensions
     [CLSCompliant(false)]
     public static uint Product<TSource>(this IEnumerable<TSource> source, Func<TSource, uint> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/Int64Extensions.cs
+++ b/X10D/src/Linq/Int64Extensions.cs
@@ -15,14 +15,10 @@ public static class Int64Extensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static long Product(this IEnumerable<long> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1L, (current, value) => current * value);
     }
@@ -36,14 +32,10 @@ public static class Int64Extensions
     [CLSCompliant(false)]
     public static ulong Product(this IEnumerable<ulong> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1UL, (current, value) => current * value);
     }
@@ -59,14 +51,10 @@ public static class Int64Extensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static long Product<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }
@@ -83,14 +71,10 @@ public static class Int64Extensions
     [CLSCompliant(false)]
     public static ulong Product<TSource>(this IEnumerable<TSource> source, Func<TSource, ulong> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/ReadOnlySpanExtensions.cs
+++ b/X10D/src/Linq/ReadOnlySpanExtensions.cs
@@ -21,14 +21,10 @@ public static class ReadOnlySpanExtensions
     [Pure]
     public static bool All<TSource>(this ReadOnlySpan<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {
@@ -60,14 +56,10 @@ public static class ReadOnlySpanExtensions
     [Pure]
     public static bool Any<TSource>(this ReadOnlySpan<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {
@@ -97,14 +89,10 @@ public static class ReadOnlySpanExtensions
     /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
     public static int Count<TSource>(this ReadOnlySpan<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {

--- a/X10D/src/Linq/SingleExtensions.cs
+++ b/X10D/src/Linq/SingleExtensions.cs
@@ -13,14 +13,10 @@ public static class SingleExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static float Product(this IEnumerable<float> source)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Aggregate(1f, (current, value) => (current * value));
     }
@@ -36,14 +32,10 @@ public static class SingleExtensions
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
     public static float Product<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         return source.Select(selector).Product();
     }

--- a/X10D/src/Linq/SpanExtensions.cs
+++ b/X10D/src/Linq/SpanExtensions.cs
@@ -21,14 +21,10 @@ public static class SpanExtensions
     [Pure]
     public static bool All<TSource>(this Span<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {
@@ -60,14 +56,10 @@ public static class SpanExtensions
     [Pure]
     public static bool Any<TSource>(this Span<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {
@@ -97,14 +89,10 @@ public static class SpanExtensions
     /// <exception cref="ArgumentNullException"><paramref name="predicate" /> is <see langword="null" />.</exception>
     public static int Count<TSource>(this Span<TSource> source, Predicate<TSource> predicate)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(predicate);
-#else
         if (predicate is null)
         {
             throw new ArgumentNullException(nameof(predicate));
         }
-#endif
 
         if (source.IsEmpty)
         {

--- a/X10D/src/Math/ComparableExtensions.cs
+++ b/X10D/src/Math/ComparableExtensions.cs
@@ -56,14 +56,10 @@ public static class ComparableExtensions
         where T2 : IComparable<T3>
         where T3 : IComparable<T2>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (lower.GreaterThan(upper))
         {
@@ -114,14 +110,10 @@ public static class ComparableExtensions
     public static T Clamp<T>(this T value, T lower, T upper)
         where T : IComparable<T>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (lower.GreaterThan(upper))
         {
@@ -160,14 +152,10 @@ public static class ComparableExtensions
     public static bool GreaterThan<T1, T2>(this T1 value, T2 other)
         where T1 : IComparable<T2>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.CompareTo(other) > 0;
     }
@@ -199,14 +187,10 @@ public static class ComparableExtensions
     public static bool GreaterThanOrEqualTo<T1, T2>(this T1 value, T2 other)
         where T1 : IComparable<T2>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.CompareTo(other) >= 0;
     }
@@ -238,14 +222,10 @@ public static class ComparableExtensions
     public static bool LessThan<T1, T2>(this T1 value, T2 other)
         where T1 : IComparable<T2>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.CompareTo(other) < 0;
     }
@@ -277,14 +257,10 @@ public static class ComparableExtensions
     public static bool LessThanOrEqualTo<T1, T2>(this T1 value, T2 other)
         where T1 : IComparable<T2>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.CompareTo(other) <= 0;
     }
@@ -315,14 +291,10 @@ public static class ComparableExtensions
     public static T Max<T>(this T value, T other)
         where T : IComparable<T>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.GreaterThan(other) ? value : other;
     }
@@ -353,14 +325,10 @@ public static class ComparableExtensions
     public static T Min<T>(this T value, T other)
         where T : IComparable<T>
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.LessThan(other) ? value : other;
     }

--- a/X10D/src/Net/EndPointExtensions.cs
+++ b/X10D/src/Net/EndPointExtensions.cs
@@ -26,14 +26,10 @@ public static class EndPointExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string GetHost(this EndPoint endPoint)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(endPoint);
-#else
         if (endPoint is null)
         {
             throw new ArgumentNullException(nameof(endPoint));
         }
-#endif
 
         return endPoint switch
         {
@@ -59,14 +55,10 @@ public static class EndPointExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static int GetPort(this EndPoint endPoint)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(endPoint);
-#else
         if (endPoint is null)
         {
             throw new ArgumentNullException(nameof(endPoint));
         }
-#endif
 
         return endPoint switch
         {

--- a/X10D/src/Net/IPAddressExtensions.cs
+++ b/X10D/src/Net/IPAddressExtensions.cs
@@ -23,14 +23,10 @@ public static class IPAddressExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsIPv4(this IPAddress address)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(address);
-#else
         if (address is null)
         {
             throw new ArgumentNullException(nameof(address));
         }
-#endif
 
         return address.AddressFamily == AddressFamily.InterNetwork;
     }
@@ -47,14 +43,10 @@ public static class IPAddressExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsIPv6(this IPAddress address)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(address);
-#else
         if (address is null)
         {
             throw new ArgumentNullException(nameof(address));
         }
-#endif
 
         return address.AddressFamily == AddressFamily.InterNetworkV6;
     }

--- a/X10D/src/Numerics/RandomExtensions.cs
+++ b/X10D/src/Numerics/RandomExtensions.cs
@@ -21,14 +21,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static Quaternion NextRotation(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         int seed = random.Next();
         var seededRandom = new Random(seed);
@@ -48,14 +44,10 @@ public static class RandomExtensions
     /// <exception cref="ArgumentNullException"><paramref name="random" /> is <see langword="null" />.</exception>
     public static Quaternion NextRotationUniform(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         int seed = random.Next();
         var seededRandom = new Random(seed);
@@ -84,14 +76,10 @@ public static class RandomExtensions
     /// </returns>
     public static Vector2 NextUnitVector2(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         // no need to construct a seeded random here, since we only call Next once
 
@@ -112,14 +100,10 @@ public static class RandomExtensions
     /// </returns>
     public static Vector3 NextUnitVector3(this Random random)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(random);
-#else
         if (random is null)
         {
             throw new ArgumentNullException(nameof(random));
         }
-#endif
 
         int seed = random.Next();
         var seededRandom = new Random(seed);

--- a/X10D/src/Reactive/ObservableDisposer.cs
+++ b/X10D/src/Reactive/ObservableDisposer.cs
@@ -17,23 +17,8 @@ internal readonly struct ObservableDisposer<T> : IDisposable
     /// <param name="additionalAction">The additional action to run on dispose.</param>
     public ObservableDisposer(HashSet<IObserver<T>> observers, IObserver<T> observer, Action? additionalAction)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(observers);
-        ArgumentNullException.ThrowIfNull(observer);
-#else
-        if (observers is null)
-        {
-            throw new ArgumentNullException(nameof(observers));
-        }
-
-        if (observer is null)
-        {
-            throw new ArgumentNullException(nameof(observer));
-        }
-#endif
-
-        _observers = observers;
-        _observer = observer;
+        _observers = observers ?? throw new ArgumentNullException(nameof(observers));
+        _observer = observer ?? throw new ArgumentNullException(nameof(observer));
         _additionalAction = additionalAction;
     }
 

--- a/X10D/src/Reactive/ProgressExtensions.cs
+++ b/X10D/src/Reactive/ProgressExtensions.cs
@@ -18,14 +18,10 @@ public static class ProgressExtensions
     /// <exception cref="ArgumentNullException"><paramref name="progress" /> is <see langword="null" />.</exception>
     public static IObservable<T> OnProgressChanged<T>(this Progress<T> progress)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(progress);
-#else
         if (progress is null)
         {
             throw new ArgumentNullException(nameof(progress));
         }
-#endif
 
         var progressObservable = new ProgressObservable<T>();
 
@@ -59,14 +55,10 @@ public static class ProgressExtensions
     /// <exception cref="ArgumentNullException"><paramref name="progress" /> is <see langword="null" />.</exception>
     public static IObservable<T> OnProgressChanged<T>(this Progress<T> progress, T completeValue)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(progress);
-#else
         if (progress is null)
         {
             throw new ArgumentNullException(nameof(progress));
         }
-#endif
 
         var progressObservable = new ProgressObservable<T>();
         var comparer = EqualityComparer<T>.Default;

--- a/X10D/src/Reactive/ProgressObservable.cs
+++ b/X10D/src/Reactive/ProgressObservable.cs
@@ -25,14 +25,10 @@ internal sealed class ProgressObservable<T> : IObservable<T>
     /// <returns>An object which can be disposed to unsubscribe from progress tracking.</returns>
     public IDisposable Subscribe(IObserver<T> observer)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(observer);
-#else
         if (observer is null)
         {
             throw new ArgumentNullException(nameof(observer));
         }
-#endif
 
         _observers.Add(observer);
         return new ObservableDisposer<T>(_observers, observer, OnDispose);

--- a/X10D/src/Reflection/MemberInfoExtensions.cs
+++ b/X10D/src/Reflection/MemberInfoExtensions.cs
@@ -26,14 +26,11 @@ public static class MemberInfoExtensions
     public static bool HasCustomAttribute<T>(this MemberInfo member)
         where T : Attribute
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
         }
-#endif
+
         return Attribute.IsDefined(member, typeof(T));
     }
 
@@ -51,10 +48,6 @@ public static class MemberInfoExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool HasCustomAttribute(this MemberInfo member, Type attribute)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-        ArgumentNullException.ThrowIfNull(attribute);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
@@ -64,7 +57,6 @@ public static class MemberInfoExtensions
         {
             throw new ArgumentNullException(nameof(attribute));
         }
-#endif
 
         if (!attribute.Inherits<Attribute>())
         {
@@ -94,10 +86,6 @@ public static class MemberInfoExtensions
         Func<TAttribute, TReturn> selector)
         where TAttribute : Attribute
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
@@ -107,7 +95,6 @@ public static class MemberInfoExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         return member.SelectFromCustomAttribute(selector, default);
     }
@@ -132,10 +119,6 @@ public static class MemberInfoExtensions
         Func<TAttribute, TReturn> selector, TReturn? defaultValue)
         where TAttribute : Attribute
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(member);
-        ArgumentNullException.ThrowIfNull(selector);
-#else
         if (member is null)
         {
             throw new ArgumentNullException(nameof(member));
@@ -145,7 +128,6 @@ public static class MemberInfoExtensions
         {
             throw new ArgumentNullException(nameof(selector));
         }
-#endif
 
         return member.GetCustomAttribute<TAttribute>() is { } attribute
             ? selector(attribute)

--- a/X10D/src/Reflection/TypeExtensions.cs
+++ b/X10D/src/Reflection/TypeExtensions.cs
@@ -21,14 +21,10 @@ public static class TypeExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool Implements<T>(this Type value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.Implements(typeof(T));
     }
@@ -48,10 +44,6 @@ public static class TypeExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool Implements(this Type value, Type interfaceType)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(interfaceType);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
@@ -61,7 +53,6 @@ public static class TypeExtensions
         {
             throw new ArgumentNullException(nameof(interfaceType));
         }
-#endif
 
         if (!interfaceType.IsInterface)
         {
@@ -90,14 +81,10 @@ public static class TypeExtensions
     public static bool Inherits<T>(this Type value)
         where T : class
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.Inherits(typeof(T));
     }
@@ -125,10 +112,6 @@ public static class TypeExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool Inherits(this Type value, Type type)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(type);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
@@ -138,7 +121,6 @@ public static class TypeExtensions
         {
             throw new ArgumentNullException(nameof(type));
         }
-#endif
 
         if (!value.IsClass)
         {

--- a/X10D/src/Text/EnumerableExtensions.cs
+++ b/X10D/src/Text/EnumerableExtensions.cs
@@ -18,10 +18,6 @@ public static class EnumerableExtensions
     /// </exception>
     public static IEnumerable<string> Grep(this IEnumerable<string> source, string pattern)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(pattern);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -31,7 +27,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(pattern));
         }
-#endif
 
         return Grep(source, pattern, false);
     }
@@ -50,10 +45,6 @@ public static class EnumerableExtensions
     /// </exception>
     public static IEnumerable<string> Grep(this IEnumerable<string> source, string pattern, bool ignoreCase)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-        ArgumentNullException.ThrowIfNull(pattern);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
@@ -63,7 +54,6 @@ public static class EnumerableExtensions
         {
             throw new ArgumentNullException(nameof(pattern));
         }
-#endif
 
 #if NET6_0_OR_GREATER
         if (source.TryGetNonEnumeratedCount(out int count) && count == 0)

--- a/X10D/src/Text/StringBuilderReader.cs
+++ b/X10D/src/Text/StringBuilderReader.cs
@@ -55,14 +55,10 @@ public class StringBuilderReader : TextReader
     /// <inheritdoc />
     public override int Read(char[] buffer, int index, int count)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(buffer);
-#else
         if (buffer is null)
         {
             throw new ArgumentNullException(nameof(buffer));
         }
-#endif
 
         if (index < 0)
         {

--- a/X10D/src/Text/StringExtensions.cs
+++ b/X10D/src/Text/StringExtensions.cs
@@ -60,14 +60,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Base64Decode(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return Convert.FromBase64String(value).ToString(Encoding.ASCII);
     }
@@ -82,14 +78,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Base64Encode(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return Convert.ToBase64String(value.GetBytes(Encoding.ASCII));
     }
@@ -115,11 +107,6 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string ChangeEncoding(this string value, Encoding sourceEncoding, Encoding destinationEncoding)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(sourceEncoding);
-        ArgumentNullException.ThrowIfNull(destinationEncoding);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
@@ -134,7 +121,6 @@ public static class StringExtensions
         {
             throw new ArgumentNullException(nameof(destinationEncoding));
         }
-#endif
 
         return value.GetBytes(sourceEncoding).ToString(destinationEncoding);
     }
@@ -179,14 +165,10 @@ public static class StringExtensions
     /// <returns>An integer representing the count of <paramref name="needle" /> inside <paramref name="haystack" />.</returns>
     public static int CountSubstring(this string haystack, char needle)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(haystack);
-#else
         if (haystack is null)
         {
             throw new ArgumentNullException(nameof(haystack));
         }
-#endif
 
         return haystack.AsSpan().CountSubstring(needle);
     }
@@ -211,14 +193,10 @@ public static class StringExtensions
     /// <returns>An integer representing the count of <paramref name="needle" /> inside <paramref name="haystack" />.</returns>
     public static int CountSubstring(this string haystack, string? needle, StringComparison comparison)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(haystack);
-#else
         if (haystack is null)
         {
             throw new ArgumentNullException(nameof(haystack));
         }
-#endif
 
         if (string.IsNullOrWhiteSpace(needle))
         {
@@ -374,14 +352,10 @@ public static class StringExtensions
     public static T EnumParse<T>(this string value, bool ignoreCase)
         where T : struct, Enum
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         value = value.Trim();
 
@@ -437,10 +411,6 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static byte[] GetBytes(this string value, Encoding encoding)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-        ArgumentNullException.ThrowIfNull(encoding);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
@@ -450,7 +420,6 @@ public static class StringExtensions
         {
             throw new ArgumentNullException(nameof(encoding));
         }
-#endif
 
         return encoding.GetBytes(value);
     }
@@ -464,14 +433,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsEmoji(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return EmojiRegex.Value.IsMatch(value);
     }
@@ -488,14 +453,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsEmpty(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         return value.Length == 0;
     }
@@ -512,14 +473,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsLower(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         for (var index = 0; index < value.Length; index++)
         {
@@ -599,14 +556,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsPalindrome(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (string.IsNullOrWhiteSpace(value))
         {
@@ -673,14 +626,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsUpper(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         for (var index = 0; index < value.Length; index++)
         {
@@ -728,14 +677,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static bool IsWhiteSpace(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (value.Length == 0)
         {
@@ -765,14 +710,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Repeat(this string value, int count)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         switch (count)
         {
@@ -810,14 +751,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Randomize(this string source, int length, Random? random = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(source);
-#else
         if (source is null)
         {
             throw new ArgumentNullException(nameof(source));
         }
-#endif
 
         if (length < 0)
         {
@@ -852,14 +789,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Reverse(this string value)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (value.Length < 2)
         {
@@ -890,14 +823,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static string Shuffled(this string value, Random? random = null)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         random ??= RandomExtensions.GetShared();
 
@@ -920,14 +849,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static IEnumerable<string> Split(this string value, int chunkSize)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(value);
-#else
         if (value is null)
         {
             throw new ArgumentNullException(nameof(value));
         }
-#endif
 
         if (chunkSize == 0)
         {
@@ -956,14 +881,10 @@ public static class StringExtensions
     /// </exception>
     public static bool StartsWithAny(this string? value, params string[] startValues)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(startValues);
-#else
         if (startValues is null)
         {
             throw new ArgumentNullException(nameof(startValues));
         }
-#endif
 
         if (startValues.Length == 0 || string.IsNullOrWhiteSpace(value))
         {
@@ -989,14 +910,10 @@ public static class StringExtensions
     /// </exception>
     public static bool StartsWithAny(this string? value, StringComparison comparison, params string[] startValues)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(startValues);
-#else
         if (startValues is null)
         {
             throw new ArgumentNullException(nameof(startValues));
         }
-#endif
 
         if (startValues.Length == 0 || string.IsNullOrWhiteSpace(value))
         {

--- a/X10D/src/Time/StringExtensions.cs
+++ b/X10D/src/Time/StringExtensions.cs
@@ -61,14 +61,10 @@ public static class StringExtensions
     [MethodImpl(CompilerResources.MethodImplOptions)]
     public static TimeSpan ToTimeSpan(this string input)
     {
-#if NET6_0_OR_GREATER
-        ArgumentNullException.ThrowIfNull(input);
-#else
         if (input is null)
         {
             throw new ArgumentNullException(nameof(input));
         }
-#endif
 
         return TimeSpanParser.TryParse(input, out TimeSpan result)
             ? result


### PR DESCRIPTION
This PR resolves #80 by removing all calls to `ArgumentNullException.ThrowIfNull`, replacing them with a null check and explicit `throw` statement